### PR TITLE
Session variables

### DIFF
--- a/toyz/utils/core.py
+++ b/toyz/utils/core.py
@@ -387,7 +387,7 @@ def get_toyz_module(toyz_settings, user_id, module):
     else:
         raise ToyzJobError(module+" not found in " +user_id+"'s approved modules")
 
-def run_job(toyz_settings, job):
+def run_job(toyz_settings, session_vars, pipe, job):
     """
     Loads modules and runs a job (function) sent from a client. Any errors will be trapped 
     and flagged as a :py:class:`toyz.utils.errors.ToyzError` and sent back to the client who 
@@ -404,6 +404,17 @@ def run_job(toyz_settings, job):
         toyz_settings ( :py:class:`toyz.utils.core.ToyzSettings` ):
             - Settings for the application runnning the job (may be needed to load user info 
               or check permissions)
+        session_vars: *dict*
+            - Global variables for the current session. This allows large files to be 
+              stored in memory instead of neeing to be reloaded by each job, but add
+              new global variables with caution. If multiple users have sessions running
+              this can quickly take up a lot of memory.
+        pipe: *multiprocessing.Pipe*
+            - Communication with the parent process.
+            - It may be useful to pass progress notifications to a client as a job
+              is run. To send a notifaction the pipe requires a dictionary that is of the
+              same form as the result (see Returns below), but usually with 
+              ``id='notification'``.
         job: *dict*
             - The job received from the user. Each job will contain the following keys:
             - ``id`` (*dict*): Unique values for the given job. These are the
@@ -488,7 +499,7 @@ def run_job(toyz_settings, job):
             ToyzJobError(job['module']+" not found in " + 
                 job['id']['user_id']+"'s approved modules")
         task = getattr(toyz_module, job["task"])
-        response = task(toyz_settings, job['id'],job['parameters'])
+        response = task(toyz_settings, session_vars, pipe, job['id'], job['parameters'])
     except ToyzJobError as error:
         response = {
             'id':"ERROR",

--- a/toyz/utils/core.py
+++ b/toyz/utils/core.py
@@ -387,7 +387,7 @@ def get_toyz_module(toyz_settings, user_id, module):
     else:
         raise ToyzJobError(module+" not found in " +user_id+"'s approved modules")
 
-def run_job(toyz_settings, session_vars, pipe, job):
+def run_job(toyz_settings, pipe, job):
     """
     Loads modules and runs a job (function) sent from a client. Any errors will be trapped 
     and flagged as a :py:class:`toyz.utils.errors.ToyzError` and sent back to the client who 
@@ -404,11 +404,6 @@ def run_job(toyz_settings, session_vars, pipe, job):
         toyz_settings ( :py:class:`toyz.utils.core.ToyzSettings` ):
             - Settings for the application runnning the job (may be needed to load user info 
               or check permissions)
-        session_vars: *dict*
-            - Global variables for the current session. This allows large files to be 
-              stored in memory instead of neeing to be reloaded by each job, but add
-              new global variables with caution. If multiple users have sessions running
-              this can quickly take up a lot of memory.
         pipe: *multiprocessing.Pipe*
             - Communication with the parent process.
             - It may be useful to pass progress notifications to a client as a job
@@ -499,7 +494,7 @@ def run_job(toyz_settings, session_vars, pipe, job):
             ToyzJobError(job['module']+" not found in " + 
                 job['id']['user_id']+"'s approved modules")
         task = getattr(toyz_module, job["task"])
-        response = task(toyz_settings, session_vars, pipe, job['id'], job['parameters'])
+        response = task(toyz_settings, pipe, job['id'], job['parameters'])
     except ToyzJobError as error:
         response = {
             'id':"ERROR",

--- a/toyz/web/app.py
+++ b/toyz/web/app.py
@@ -283,13 +283,12 @@ def job_process(pipe):
     Process created for the websocket. When a job is received from the Toyz
     Application it is run in this process and a response is sent.
     """
-    session_vars = {}
     while True:
         try:
             msg = pipe.recv()    # Read from the output pipe and do nothing
             job = msg['job']
             toyz_settings = msg['toyz_settings']
-            result = core.run_job(toyz_settings, session_vars, pipe, job)
+            result = core.run_job(toyz_settings, pipe, job)
             pipe.send(result)
         except EOFError:
             break

--- a/toyz/web/session_vars.py
+++ b/toyz/web/session_vars.py
@@ -1,0 +1,3 @@
+"""
+Empty module used to store variables shared in a single Toyz session (websocket connection).
+""" 

--- a/toyz/web/tasks.py
+++ b/toyz/web/tasks.py
@@ -1,4 +1,3 @@
-
 # Job tasks sent from web client
 # Copyright 2015 by Fred Moolekamp
 # License: LGPLv3
@@ -15,9 +14,10 @@ from toyz.utils import core
 from toyz.utils import file_access
 from toyz.utils import db as db_utils
 from toyz.utils.errors import ToyzJobError
+from toyz.web import session_vars
 import six
 
-def load_user_settings(toyz_settings, session_vars, pipe, tid, params):
+def load_user_settings(toyz_settings, pipe, tid, params):
     """
     Load settings for a given user
     
@@ -95,7 +95,7 @@ def load_user_settings(toyz_settings, session_vars, pipe, tid, params):
         })
     return response
 
-def load_user_info(toyz_settings, session_vars, pipe, tid, params):
+def load_user_info(toyz_settings, pipe, tid, params):
     """
     Load info for a given user from the database
     
@@ -135,7 +135,7 @@ def load_user_info(toyz_settings, session_vars, pipe, tid, params):
     
     return response
 
-def save_user_info(toyz_settings, session_vars, pipe, tid, params):
+def save_user_info(toyz_settings, pipe, tid, params):
     """
     Save a users info. If any admin settings are being changed, ensures that the user
     is in the admin group.
@@ -194,7 +194,7 @@ def save_user_info(toyz_settings, session_vars, pipe, tid, params):
     
     return response
 
-def update_toyz_settings(toyz_settings, session_vars, pipe, tid, params):
+def update_toyz_settings(toyz_settings, pipe, tid, params):
     """
     Update the toyz settings for the application
     """
@@ -230,7 +230,7 @@ def update_toyz_settings(toyz_settings, session_vars, pipe, tid, params):
     
     return response
 
-def add_new_user(toyz_settings, session_vars, pipe, tid, params):
+def add_new_user(toyz_settings, pipe, tid, params):
     """
     Add a new user to the toyz application.
     
@@ -268,7 +268,7 @@ def add_new_user(toyz_settings, session_vars, pipe, tid, params):
     }
     return response
 
-def change_pwd(toyz_settings, session_vars, pipe, tid, params):
+def change_pwd(toyz_settings, pipe, tid, params):
     """
     Change a users password.
     
@@ -308,7 +308,7 @@ def change_pwd(toyz_settings, session_vars, pipe, tid, params):
     }
     return response
 
-def reset_pwd(toyz_settings, session_vars, pipe, tid, params):
+def reset_pwd(toyz_settings, pipe, tid, params):
     """
     Reset a users password
     """
@@ -329,7 +329,7 @@ def reset_pwd(toyz_settings, session_vars, pipe, tid, params):
     }
     return response
 
-def load_directory(toyz_settings, session_vars, pipe, tid, params):
+def load_directory(toyz_settings, pipe, tid, params):
     """
     Used by the file browser to load the folders and files in a given path.
     
@@ -411,7 +411,7 @@ def load_directory(toyz_settings, session_vars, pipe, tid, params):
     #print('path info:', response)
     return response
 
-def create_paths(toyz_settings, session_vars, pipe, tid, params):
+def create_paths(toyz_settings, pipe, tid, params):
     """
     Creates a new path on the server (if it does not already exist).
     
@@ -443,7 +443,7 @@ def create_paths(toyz_settings, session_vars, pipe, tid, params):
     }
     return response
 
-def get_workspace_info(toyz_settings, session_vars, pipe, tid, params):
+def get_workspace_info(toyz_settings, pipe, tid, params):
     """
     Get I/O settings for different packages (pure python, numpy, pandas, etc) and
     other settings for the current users workspaces
@@ -510,7 +510,7 @@ def get_workspace_info(toyz_settings, session_vars, pipe, tid, params):
     
     return response
 
-def load_data_file(toyz_settings, session_vars, pipe, tid, params):
+def load_data_file(toyz_settings, pipe, tid, params):
     """
     Load a data file given a set of parameters from the browser, initialized by
     ``get_io_info``.
@@ -532,7 +532,7 @@ def load_data_file(toyz_settings, session_vars, pipe, tid, params):
     #print('response', response)
     return response
 
-def save_workspace(toyz_settings, session_vars, pipe, tid, params):
+def save_workspace(toyz_settings, pipe, tid, params):
     """
     Save a workspace for later use
     """
@@ -555,7 +555,7 @@ def save_workspace(toyz_settings, session_vars, pipe, tid, params):
     
     return response
 
-def load_workspace(toyz_settings, session_vars, pipe, tid, params):
+def load_workspace(toyz_settings, pipe, tid, params):
     """
     Load a workspace
     """
@@ -572,7 +572,7 @@ def load_workspace(toyz_settings, session_vars, pipe, tid, params):
     
     return response
 
-def get_file_info(toyz_settings, session_vars, pipe, tid, params):
+def get_file_info(toyz_settings, pipe, tid, params):
     """
     Get information about an image file
     """
@@ -589,7 +589,7 @@ def get_file_info(toyz_settings, session_vars, pipe, tid, params):
     img_info = file_info['images'][file_info['frame']]
     img_info.update(params['img_info'])
     # Get the tile map for the first image
-    result = get_img_info(toyz_settings, session_vars, pipe, tid, {
+    result = get_img_info(toyz_settings, pipe, tid, {
         'file_info': file_info,
         'img_info': img_info
     })
@@ -602,7 +602,7 @@ def get_file_info(toyz_settings, session_vars, pipe, tid, params):
     }
     return response
 
-def get_img_info(toyz_settings, session_vars, pipe, tid, params):
+def get_img_info(toyz_settings, pipe, tid, params):
     """
     Map a large image into a set of tiles that make up the larger image
     """
@@ -621,7 +621,7 @@ def get_img_info(toyz_settings, session_vars, pipe, tid, params):
     params['img_info']['save_path'] = save_path
     img_info = viewer.get_img_info(params['file_info'], params['img_info'])
     
-    result = get_tile_info(toyz_settings, session_vars, pipe, tid, {
+    result = get_tile_info(toyz_settings, pipe, tid, {
         'file_info': params['file_info'],
         'img_info': img_info
     })
@@ -634,7 +634,7 @@ def get_img_info(toyz_settings, session_vars, pipe, tid, params):
     print('************************************************')
     return response
 
-def get_tile_info(toyz_settings, session_vars, pipe, tid, params):
+def get_tile_info(toyz_settings, pipe, tid, params):
     """
     Get new tiles that need to be loaded
     """
@@ -660,7 +660,7 @@ def get_tile_info(toyz_settings, session_vars, pipe, tid, params):
     }
     return response
 
-def get_img_tile(toyz_settings, session_vars, pipe, tid, params):
+def get_img_tile(toyz_settings, pipe, tid, params):
     """
     Load a tile from a larger image and notify the client it has been created
     """
@@ -686,7 +686,7 @@ def get_img_tile(toyz_settings, session_vars, pipe, tid, params):
     
     return response
 
-def get_img_data(toyz_settings, session_vars, pipe, tid, params):
+def get_img_data(toyz_settings, pipe, tid, params):
     """
     Get data from an image or FITS file
     """

--- a/toyz/web/tasks.py
+++ b/toyz/web/tasks.py
@@ -17,7 +17,7 @@ from toyz.utils import db as db_utils
 from toyz.utils.errors import ToyzJobError
 import six
 
-def load_user_settings(toyz_settings, tid, params):
+def load_user_settings(toyz_settings, session_vars, pipe, tid, params):
     """
     Load settings for a given user
     
@@ -95,7 +95,7 @@ def load_user_settings(toyz_settings, tid, params):
         })
     return response
 
-def load_user_info(toyz_settings, tid, params):
+def load_user_info(toyz_settings, session_vars, pipe, tid, params):
     """
     Load info for a given user from the database
     
@@ -135,7 +135,7 @@ def load_user_info(toyz_settings, tid, params):
     
     return response
 
-def save_user_info(toyz_settings, tid, params):
+def save_user_info(toyz_settings, session_vars, pipe, tid, params):
     """
     Save a users info. If any admin settings are being changed, ensures that the user
     is in the admin group.
@@ -194,7 +194,7 @@ def save_user_info(toyz_settings, tid, params):
     
     return response
 
-def update_toyz_settings(toyz_settings, tid, params):
+def update_toyz_settings(toyz_settings, session_vars, pipe, tid, params):
     """
     Update the toyz settings for the application
     """
@@ -230,7 +230,7 @@ def update_toyz_settings(toyz_settings, tid, params):
     
     return response
 
-def add_new_user(toyz_settings, tid, params):
+def add_new_user(toyz_settings, session_vars, pipe, tid, params):
     """
     Add a new user to the toyz application.
     
@@ -268,7 +268,7 @@ def add_new_user(toyz_settings, tid, params):
     }
     return response
 
-def change_pwd(toyz_settings, tid, params):
+def change_pwd(toyz_settings, session_vars, pipe, tid, params):
     """
     Change a users password.
     
@@ -308,7 +308,7 @@ def change_pwd(toyz_settings, tid, params):
     }
     return response
 
-def reset_pwd(toyz_settings, tid, params):
+def reset_pwd(toyz_settings, session_vars, pipe, tid, params):
     """
     Reset a users password
     """
@@ -329,7 +329,7 @@ def reset_pwd(toyz_settings, tid, params):
     }
     return response
 
-def load_directory(toyz_settings, tid, params):
+def load_directory(toyz_settings, session_vars, pipe, tid, params):
     """
     Used by the file browser to load the folders and files in a given path.
     
@@ -411,7 +411,7 @@ def load_directory(toyz_settings, tid, params):
     #print('path info:', response)
     return response
 
-def create_paths(toyz_settings, tid, params):
+def create_paths(toyz_settings, session_vars, pipe, tid, params):
     """
     Creates a new path on the server (if it does not already exist).
     
@@ -443,7 +443,7 @@ def create_paths(toyz_settings, tid, params):
     }
     return response
 
-def get_workspace_info(toyz_settings, tid, params):
+def get_workspace_info(toyz_settings, session_vars, pipe, tid, params):
     """
     Get I/O settings for different packages (pure python, numpy, pandas, etc) and
     other settings for the current users workspaces
@@ -510,7 +510,7 @@ def get_workspace_info(toyz_settings, tid, params):
     
     return response
 
-def load_data_file(toyz_settings, tid, params):
+def load_data_file(toyz_settings, session_vars, pipe, tid, params):
     """
     Load a data file given a set of parameters from the browser, initialized by
     ``get_io_info``.
@@ -532,7 +532,7 @@ def load_data_file(toyz_settings, tid, params):
     #print('response', response)
     return response
 
-def save_workspace(toyz_settings, tid, params):
+def save_workspace(toyz_settings, session_vars, pipe, tid, params):
     """
     Save a workspace for later use
     """
@@ -555,7 +555,7 @@ def save_workspace(toyz_settings, tid, params):
     
     return response
 
-def load_workspace(toyz_settings, tid, params):
+def load_workspace(toyz_settings, session_vars, pipe, tid, params):
     """
     Load a workspace
     """
@@ -572,7 +572,7 @@ def load_workspace(toyz_settings, tid, params):
     
     return response
 
-def get_file_info(toyz_settings, tid, params):
+def get_file_info(toyz_settings, session_vars, pipe, tid, params):
     """
     Get information about an image file
     """
@@ -589,7 +589,7 @@ def get_file_info(toyz_settings, tid, params):
     img_info = file_info['images'][file_info['frame']]
     img_info.update(params['img_info'])
     # Get the tile map for the first image
-    result = get_img_info(toyz_settings, tid, {
+    result = get_img_info(toyz_settings, session_vars, pipe, tid, {
         'file_info': file_info,
         'img_info': img_info
     })
@@ -602,7 +602,7 @@ def get_file_info(toyz_settings, tid, params):
     }
     return response
 
-def get_img_info(toyz_settings, tid, params):
+def get_img_info(toyz_settings, session_vars, pipe, tid, params):
     """
     Map a large image into a set of tiles that make up the larger image
     """
@@ -621,7 +621,7 @@ def get_img_info(toyz_settings, tid, params):
     params['img_info']['save_path'] = save_path
     img_info = viewer.get_img_info(params['file_info'], params['img_info'])
     
-    result = get_tile_info(toyz_settings, tid, {
+    result = get_tile_info(toyz_settings, session_vars, pipe, tid, {
         'file_info': params['file_info'],
         'img_info': img_info
     })
@@ -634,7 +634,7 @@ def get_img_info(toyz_settings, tid, params):
     print('************************************************')
     return response
 
-def get_tile_info(toyz_settings, tid, params):
+def get_tile_info(toyz_settings, session_vars, pipe, tid, params):
     """
     Get new tiles that need to be loaded
     """
@@ -660,7 +660,7 @@ def get_tile_info(toyz_settings, tid, params):
     }
     return response
 
-def get_img_tile(toyz_settings, tid, params):
+def get_img_tile(toyz_settings, session_vars, pipe, tid, params):
     """
     Load a tile from a larger image and notify the client it has been created
     """
@@ -686,7 +686,7 @@ def get_img_tile(toyz_settings, tid, params):
     
     return response
 
-def get_img_data(toyz_settings, tid, params):
+def get_img_data(toyz_settings, session_vars, pipe, tid, params):
     """
     Get data from an image or FITS file
     """

--- a/toyz/web/viewer.py
+++ b/toyz/web/viewer.py
@@ -410,7 +410,7 @@ def get_img_data(data_type, file_info, img_info, **kwargs):
     elif data_type == 'datapoint':
         return {
             'id': 'datapoint',
-            'px_value': data.tolist()[kwargs['y']][kwargs['x']]
+            'px_value': float(data[kwargs['y'],kwargs['x']])
         }
     else:
         raise ToyzJobError("Loading that data type has not been implemented yet")

--- a/toyz/web/viewer.py
+++ b/toyz/web/viewer.py
@@ -5,7 +5,18 @@ from collections import OrderedDict
 from toyz.utils.errors import ToyzJobError
 import math
 import os
+import numpy as np
 from toyz.utils import core
+from toyz.web import session_vars
+
+# Set the default values for the sessions global variables if they have not already been set
+viewer_variables = {
+    'filepath': None,
+    'img_file': None,
+}
+for v in viewer_variables:
+    if not hasattr(session_vars, v):
+        setattr(session_vars, v, viewer_variables[v])
 
 # It may be desirabe in the future to allow users to choose what type of image they
 # want to send to the client. For now the default is sent to jpg, since it is the
@@ -40,6 +51,24 @@ def import_fits():
                 "You must have astropy or pyfits installed to view FITS images")
     return pyfits
 
+def get_file(file_info):
+    """
+    If the image has already been loaded into memory, access it here.
+    Otherwise, store the image for later use
+    """
+    if session_vars.filepath == file_info['filepath']:
+        img_file = session_vars.img_file
+    else:
+        print('loading', file_info['filepath'])
+        if file_info['ext'].lower() == 'fits' or file_info['ext'].lower() == 'fits.fz':
+            pyfits = import_fits()
+            img_file = pyfits.open(file_info['filepath'])
+        else:
+            img_file = Image.open(file_info['filepath'])
+        session_vars.filepath = file_info['filepath']
+        session_vars.img_file = img_file
+    return img_file
+
 def get_file_info(file_info):
     file_split = file_info['filepath'].split('.')
     file_info['filename'] = os.path.basename(file_split[0])
@@ -53,10 +82,7 @@ def get_file_info(file_info):
         file_info['img_type'] == 'image'
     
     if file_info['ext'].lower() == 'fits' or file_info['ext'].lower() == 'fits.fz':
-        pyfits = import_fits()
-        import numpy as np
-        
-        hdulist = pyfits.open(file_info['filepath'])
+        hdulist = get_file(file_info)
         file_info['hdulist'] = [hdu.__class__.__name__ for hdu in hdulist]
         if 'images' not in file_info:
             file_info['images'] = OrderedDict(
@@ -109,9 +135,7 @@ def get_best_fit(data_width, data_height, img_viewer):
 
 def get_img_info(file_info, img_info):
     if file_info['ext'].lower() == 'fits' or file_info['ext'].lower() == 'fits.fz':
-        pyfits = import_fits()
-        import numpy as np
-        hdulist = pyfits.open(file_info['filepath'])
+        hdulist = get_file(file_info)
         data = hdulist[int(img_info['frame'])].data
         height, width = data.shape
         
@@ -139,9 +163,7 @@ def get_img_info(file_info, img_info):
                 "You must have PIL (Python Imaging Library) installed to "
                 "open files of this type"
             )
-        import numpy as np
-        
-        img = Image.open(file_info['filepath'])
+        img = get_file(file_info)
         img_info['colormap'] = {}
         width, height = img.size
     img_info['width'] = width
@@ -261,7 +283,6 @@ def get_tile_info(file_info, img_info):
     return all_tiles, new_tiles
 
 def scale_data(file_info, img_info, tile_info, data):
-    import numpy as np
     if img_info['scale']==1:
         data = data[tile_info['y0_idx']:tile_info['yf_idx'],
             tile_info['x0_idx']:tile_info['xf_idx']]
@@ -305,15 +326,13 @@ def create_tile(file_info, img_info, tile_info):
         )
     
     if file_info['ext'].lower() == 'fits' or file_info['ext'].lower() == 'fits.fz':
-        pyfits = import_fits()
-        import numpy as np
         try:
             from matplotlib import cm as cmap
             from matplotlib.colors import Normalize, LinearSegmentedColormap
         except ImportError:
             raise ToyzJobError("You must have matplotlib installed to load FITS images")
         
-        hdulist = pyfits.open(file_info['filepath'])
+        hdulist = get_file(file_info)
         data = hdulist[int(img_info['frame'])].data
         # If no advanced resampling algorithm is used, scale the data as quickly as possible.
         # Otherwise crop the data.
@@ -342,7 +361,7 @@ def create_tile(file_info, img_info, tile_info):
                 (tile_info['width'], tile_info['height']), 
                 getattr(Image, file_info['resampling']))
     else:
-        img = Image.open(file_info['filepath'])
+        img = get_file(file_info)
         img = img.crop((
             tile_info['x0_idx'], tile_info['y0_idx'], 
             tile_info['xf_idx'], 
@@ -364,8 +383,7 @@ def get_img_data(data_type, file_info, img_info, **kwargs):
     """
     if data_type == 'data' or data_type == 'datapoint':
         if file_info['ext'].lower() == 'fits' or file_info['ext'].lower() == 'fits.fz':
-            pyfits = import_fits()
-            hdulist = pyfits.open(file_info['filepath'])
+            hdulist = get_file(file_info)
             data = hdulist[int(img_info['frame'])].data
         else:
             try:
@@ -375,8 +393,7 @@ def get_img_data(data_type, file_info, img_info, **kwargs):
                     "You must have PIL (Python Imaging Library) installed to "
                     "open files of this type"
                 )
-            import numpy as np
-            img = Image.open(file_info['filepath'])
+            img = get_file(file_info)
             data = np.array(img)
     
     if data_type == 'data':


### PR DESCRIPTION
Changed how jobs are run: instead of each task running in a new process, each session has its own process with saved variables, so that large images or data files can be stored in memory instead of requiring the application to reload them for each function call.

Also changed the Job API so that tasks now accept a 'pipe' variable, that allows them to send profress notifications to the client